### PR TITLE
Fixed backspace and autoclear

### DIFF
--- a/calculator.js
+++ b/calculator.js
@@ -19,24 +19,12 @@ var autoclear = false;
 
 function renderContent() {
   // Create base elements for the page
-  var container = createElement('div', '', {
-    id: 'container'
-  });
-  var header = createElement('div', '', {
-    id: 'header'
-  });
-  var nav = createElement('div', '', {
-    id: 'nav'
-  });
-  var main = createElement('div', '', {
-    id: 'main'
-  });
-  var aside = createElement('div', '', {
-    id: 'aside'
-  });
-  var footer = createElement('div', '', {
-    id: 'footer'
-  });
+  var container = createElement('div', '', { id: 'container' });
+  var header =    createElement('div', '', { id: 'header' });
+  var nav =       createElement('div', '', { id: 'nav' });
+  var main =      createElement('div', '', { id: 'main' });
+  var aside =     createElement('div', '', { id: 'aside' });
+  var footer =    createElement('div', '', { id: 'footer' });
 
   // Append main elements to container
   container.appendChild(header);
@@ -46,9 +34,7 @@ function renderContent() {
   container.appendChild(footer);
 
   // Insert content
-  header.appendChild(createElement('h1', 'Calculator', {
-    className: 'title'
-  }));
+  header.appendChild(createElement('h1', 'Calculator', { className: 'title' }));
   main.appendChild(calculator());
   footer.appendChild(footerButtons());
   footer.appendChild(about());

--- a/calculator.js
+++ b/calculator.js
@@ -199,50 +199,5 @@ function handleButton(event) {
     this.blur();
   }
 }
-/*
-
-if(!isNaN(event.target.id)) {
-  // If last operation was math.eval then start new string
-  if(lastNum == 'new') {
-    box.value = '';
-  }
-  // Append new value
-  box.value = box.value + event.target.id;
-  lastNum = event.target.id;
-// If clicked button is not a number
-} else {
-  // If clicked button is '='
-  if(event.target.id == '=') {
-    // Evaluate current string
-    answer = math.eval(box.value)
-    if(isNaN(answer)){
-      //
-    } else {
-      box.value = answer;
-    }
-    // Note that the last operation was an eval
-    lastNum = 'new';
-  // If clicked button is an operation
-  } else {
-    // If the last button clicked was a number, allow the operator to be appended
-    if(!isNaN(lastNum)) {
-      box.value = box.value + event.target.id;
-      lastNum = event.target.id;
-    }
-  }
-}
-// Remove keyboard focus on button
-this.blur();
-} if(event.target.id == '=') {
-// Evaluate current string
-answer = math.eval(box.value)
-if(isNaN(answer)){
-  //
-} else {
-  box.value = answer;
-}
-// Note that the last operation was an eval
-lastNum = 'new';
-*/
 
 renderContent();

--- a/calculator.js
+++ b/calculator.js
@@ -15,7 +15,7 @@ var buttons = ['7', '8', '9', '+',
 
 var lastNum = 'new';
 var answer;
-var autoclear = false;
+var autoclear = true;
 
 function renderContent() {
   // Create base elements for the page
@@ -77,8 +77,11 @@ function calculator() {
 function footerButtons() {
   var btnWrapper = createElement('div', '');
 
-  var span = createElement('span', 'OFF', { id: 'spantxt' });
-  var autoclr = createElement('button', 'Auto Clear: ', { className: 'auto-false', id: 'autoclr' });
+  var span = createElement('span', (autoclear ? 'ON' : 'OFF'), { id: 'spantxt' });
+  var autoclr = createElement('button', 'Auto Clear: ', {
+    className: (autoclear ? 'auto-true' : 'auto-false'),
+    id: 'autoclr'
+  });
   autoclr.addEventListener('click', function(event){
     if(autoclr.className == 'auto-false'){
       autoclr.className = 'auto-true';
@@ -147,11 +150,10 @@ function handleButton(event) {
 
   if (!(box === document.activeElement)) {
     // Solve
-    if(autoclear){
-      if(lastNum == '=') {
-        box.value = '';
-      }
-    }
+    if (autoclear)
+      if (lastNum == '=')
+        if (! /[-+*^/]/.test(event.target.id))
+          box.value = '';
     if (event.target.id == '=') {
       var temp = box.value.replace(/ln\(/g, 'log(');
       answer = math.eval(temp);

--- a/calculator.js
+++ b/calculator.js
@@ -124,25 +124,23 @@ function about() {
 // Need to rewrite keypress to be more efficient
 
 // If Enter/Return is pressed, click '=' to evaluate
-document.addEventListener('keypress', function(key) {
-  var keyString = String.fromCharCode(key.charCode);
-  if (key.keyCode == 13) {
+document.addEventListener('keypress', function(ev) {
+  var keyString = String.fromCharCode(ev.charCode);
+  if (ev.keyCode == 13) {
     document.getElementById('=').click();
   } else if (/[0-9]|[-/*+=.^()]/.test(keyString)) {
     document.getElementById(keyString).click();
-  } else if (key.keyCode == 8) {
-    var box = document.getElementById('cal-box')
-    if (box === document.activeElement) {
-      //
-    } else {
-      if (box.value == '') {
-        // Do nothing
-      } else {
-        document.getElementById('<-').click();
-      }
-    }
-  } // keyCode 46 is Delete
-}, false);
+  }
+});
+// Backspace
+document.addEventListener('keydown', function(ev) {
+  if (ev.keyCode == 8) {
+    var box = document.getElementById('cal-box');
+    if (box !== document.activeElement)
+      document.getElementById('<-').click();
+    ev.preventDefault();
+  }
+});
 
 function handleButton(event) {
   var box = document.getElementById('cal-box');


### PR DESCRIPTION
- Fixed backspace by moving it into `keydown` instead of `keypress` and calling `preventDefault` to prevent the page from going back in history
- Fixed auto clear to not clear if an operation is pressed (–, +, /, *, ^)
- This should make auto clear behave as expected, so setting it by default
